### PR TITLE
Support DeepSeek provider for copy generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,33 @@
+# Taobao API credentials
+TB_APP_KEY=your_app_key
+TB_APP_SECRET=your_app_secret
+TB_ADZONE_ID=your_adzone_id
+# Optional: override the default endpoint
+# TB_ENDPOINT=https://eco.taobao.com/router/rest
+
+# Database connection string (SQLAlchemy URL)
+# Examples:
+#   postgresql+psycopg2://user:password@localhost:5432/hotflow
+#   mysql+pymysql://user:password@localhost:3306/hotflow
+#   sqlite:///hotflow.db
+HOTFLOW_DATABASE_URL=sqlite:///hotflow.db
+
+# Copy generation provider configuration
+# Supported providers: openai (default), deepseek
+# HOTFLOW_COPY_PROVIDER=openai
+
+# OpenAI credentials for copy generation
+OPENAI_API_KEY=your_openai_key
+# Optional: override defaults
+# OPENAI_MODEL=gpt-4o-mini
+# OPENAI_TEMPERATURE=0.7
+# OPENAI_BASE_URL=
+
+# DeepSeek credentials (used when HOTFLOW_COPY_PROVIDER=deepseek)
+# DEEPSEEK_API_KEY=your_deepseek_key
+# DEEPSEEK_MODEL=deepseek-chat
+# DEEPSEEK_TEMPERATURE=0.7
+# DEEPSEEK_BASE_URL=https://api.deepseek.com
+
+# Optional: override fetch keywords (comma separated)
+# HOTFLOW_KEYWORDS=抽纸,洗衣液,猫粮,狗粮,猫砂

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+.env
+.venv/
+.pytest_cache/
+.mypy_cache/
+.DS_Store
+.cache/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,113 @@
 # HotFlow
+
+一套围绕淘宝联盟数据抓取与 AI 文案生成的最小可行方案，默认覆盖抽纸、洗衣液、猫粮、狗粮、猫砂五大高频品类。项目提供端到端的流程：
+
+1. 从淘宝联盟开放平台定时拉取热卖商品数据；
+2. 将数据存入关系型数据库，方便后续筛选与扩展；
+3. 通过 OpenAI 或 DeepSeek 模型生成多平台、多风格的营销文案，并落库备份。
+
+## 快速开始
+
+### 1. 安装依赖
+
+推荐使用 Python 3.10+ 与虚拟环境：
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e '.[dev]'
+```
+
+### 2. 配置环境变量
+
+复制 `.env.example` 为 `.env` 并填入淘宝联盟与文案生成模型（OpenAI 或 DeepSeek）的密钥：
+
+```bash
+cp .env.example .env
+# 编辑 .env 文件，写入实际凭据
+```
+
+关键环境变量说明：
+
+| 变量 | 说明 |
+| --- | --- |
+| `TB_APP_KEY` / `TB_APP_SECRET` | 淘宝联盟开放平台凭据 |
+| `TB_ADZONE_ID` | 推广位 ID |
+| `HOTFLOW_DATABASE_URL` | SQLAlchemy 兼容的数据库地址（MySQL / PostgreSQL / SQLite） |
+| `HOTFLOW_COPY_PROVIDER` | （可选）文案生成模型供应商，默认 `openai`，可选 `deepseek` |
+| `OPENAI_API_KEY` | 当 provider 为 `openai` 时所需的 API Key |
+| `DEEPSEEK_API_KEY` | 当 provider 为 `deepseek` 时所需的 API Key |
+| `HOTFLOW_KEYWORDS` | （可选）自定义抓取关键词，默认即五大品类 |
+
+> 如果使用 DeepSeek，只需设置 `HOTFLOW_COPY_PROVIDER=deepseek` 与 `DEEPSEEK_API_KEY`；模型名默认 `deepseek-chat`，也可通过 `DEEPSEEK_MODEL` 或 CLI 参数 `--openai-model` 覆盖。
+
+### 3. 初始化数据库
+
+```bash
+hotflow init-db
+```
+
+### 4. 抓取商品数据
+
+```bash
+# 默认抓取 .env 中配置的关键词，可通过 --keyword 追加/覆盖
+hotflow fetch --pages 2 --page-size 40
+```
+
+命令会自动完成签名、调用 `taobao.tbk.dg.material.optional` 接口，并将结果写入 `taoke_items` 表。数据库结构定义在 `hotflow/db.py` 中，可根据实际业务扩展字段。
+
+### 5. 生成 AI 文案
+
+```bash
+# 为最新商品生成三种平台文案
+hotflow generate-copy --variants 3
+
+# 临时切换为 DeepSeek 生成（会读取 .env 中 DeepSeek 凭据）
+# hotflow --copy-provider deepseek generate-copy
+```
+
+生成流程：
+
+1. 读取数据库中的商品信息；
+2. 使用 `hotflow/prompts.py` 的模板构建 Prompt；
+3. 调用所选 LLM（OpenAI / DeepSeek）Chat Completion 接口，要求返回 JSON 格式的多平台文案；
+4. 解析后写入 `creatives` 表，方便后续 A/B 测试或人工审核。
+
+### 6. 查看结果
+
+```bash
+# 列出最近的商品
+hotflow list-items --limit 5
+
+# 查看生成的文案
+hotflow list-creatives --limit 5
+```
+
+## 架构概览
+
+- **配置层**：`hotflow/config.py` 从环境变量加载淘宝、数据库、文案生成模型（OpenAI / DeepSeek）等信息，支持命令行动态覆盖。
+- **抓取层**：`hotflow/taobao.py` 封装 `taobao.tbk.dg.material.optional` 的请求签名、参数构建与结果解析。
+- **存储层**：`hotflow/db.py` 使用 SQLAlchemy Core 定义 `taoke_items`、`creatives` 两张核心表，提供批量写入与查询能力。
+- **AI 文案**：`hotflow/copymaker.py` + `hotflow/prompts.py` 负责 Prompt 渲染、调用所选 LLM、JSON 解析与 `Creative` 实体落库。
+- **调度层**：`hotflow/pipeline.py` 打通「抓取 → 入库 → 文案生成」的编排逻辑；`hotflow/cli.py` 提供命令行入口，便于集成到 `cron` 或其他调度系统。
+
+## 后续扩展建议
+
+- 接入 Airflow / Prefect 等工作流框架，实现更复杂的调度与依赖管理；
+- 为商品打标签（佣金区间、销量等级、商家类型等），便于后续筛选；
+- 文案生成阶段接入 Dify、审核策略或第三方敏感词校验；
+- 增加多平台发布适配，比如小红书/微博/知乎的格式化输出或 API 对接。
+
+## 开发调试
+
+- 运行单元测试：
+
+  ```bash
+  pytest
+  ```
+
+- 代码风格：项目遵循标准 Python 类型注解与模块划分，可视需求引入 Ruff、mypy 等工具。
+
+---
+
+如需进一步定制或扩展更多品类，请在现有模块基础上调整关键词、数据库 schema 以及 Prompt 模板，即可快速复制整个流程。

--- a/hotflow/__init__.py
+++ b/hotflow/__init__.py
@@ -1,0 +1,31 @@
+"""HotFlow package with lightweight imports for optional dependencies."""
+
+from __future__ import annotations
+
+from .config import LLMSettings, Settings, load_settings
+
+try:  # pragma: no cover - optional dependency wrappers
+    from .taobao import TaobaoAPIError, TaobaoClient
+except ModuleNotFoundError:  # pragma: no cover
+    TaobaoClient = None  # type: ignore[assignment]
+    TaobaoAPIError = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency wrappers
+    from .copymaker import CopyWriter
+except ModuleNotFoundError:  # pragma: no cover
+    CopyWriter = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency wrappers
+    from .pipeline import fetch_and_store
+except ModuleNotFoundError:  # pragma: no cover
+    fetch_and_store = None  # type: ignore[assignment]
+
+__all__ = [
+    "Settings",
+    "LLMSettings",
+    "load_settings",
+    "TaobaoClient",
+    "TaobaoAPIError",
+    "CopyWriter",
+    "fetch_and_store",
+]

--- a/hotflow/cli.py
+++ b/hotflow/cli.py
@@ -1,0 +1,198 @@
+"""Command line interface for HotFlow."""
+from __future__ import annotations
+
+from typing import List, Optional, Sequence
+import logging
+
+import typer
+
+from .config import Settings, load_settings
+from .copymaker import CopyWriter
+from .db import create_tables, fetch_items, get_engine, list_creatives
+from .pipeline import fetch_and_store, generate_and_store_creatives
+from .prompts import DEFAULT_PLATFORMS
+from .taobao import TaobaoClient
+
+app = typer.Typer(help="HotFlow data ingestion and creative generation toolkit")
+
+
+def _setup_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s %(name)s: %(message)s")
+
+
+@app.callback()
+def main(
+    ctx: typer.Context,
+    verbose: bool = typer.Option(False, "-v", "--verbose", help="Enable verbose logging"),
+    database_url: Optional[str] = typer.Option(None, help="Override the database URL"),
+    keyword: List[str] = typer.Option(
+        None, "--keyword", help="Keyword(s) to fetch. Defaults to configuration keywords.", show_default=False
+    ),
+    openai_model: Optional[str] = typer.Option(None, help="Override the LLM model for copy generation"),
+    openai_temperature: Optional[float] = typer.Option(None, help="Override the LLM temperature"),
+    copy_provider: Optional[str] = typer.Option(
+        None,
+        "--copy-provider",
+        help="LLM provider for copy generation (e.g. openai, deepseek)",
+    ),
+    llm_base_url: Optional[str] = typer.Option(
+        None,
+        "--llm-base-url",
+        help="Override the base URL for the copy provider",
+    ),
+) -> None:
+    """Load configuration and prepare context."""
+
+    _setup_logging(verbose)
+    overrides = {}
+    if database_url:
+        overrides["database_url"] = database_url
+    if keyword:
+        overrides["keywords"] = keyword
+    if openai_model:
+        overrides["openai_model"] = openai_model
+    if openai_temperature is not None:
+        overrides["openai_temperature"] = openai_temperature
+    if copy_provider:
+        overrides["copy_provider"] = copy_provider
+    if llm_base_url:
+        overrides["openai_base_url"] = llm_base_url
+
+    settings = load_settings(**overrides)
+    ctx.obj = {"settings": settings}
+
+
+def _get_settings(ctx: typer.Context) -> Settings:
+    if not ctx.obj or "settings" not in ctx.obj:
+        raise typer.BadParameter("Configuration has not been loaded. Ensure the callback ran correctly.")
+    return ctx.obj["settings"]
+
+
+@app.command("init-db")
+def init_db(ctx: typer.Context) -> None:
+    """Initialize the database schema."""
+
+    settings = _get_settings(ctx)
+    engine = get_engine(settings.database_url)
+    create_tables(engine)
+    typer.echo("Database schema initialized.")
+
+
+@app.command("fetch")
+def fetch_command(
+    ctx: typer.Context,
+    pages: int = typer.Option(1, help="Number of pages to fetch for each keyword"),
+    page_size: int = typer.Option(50, help="Number of items per page"),
+    delay: float = typer.Option(1.0, help="Delay between page requests in seconds"),
+    include_no_coupon: bool = typer.Option(
+        False, "--include-no-coupon", help="Include items without coupons in the search"
+    ),
+    sort: str = typer.Option("total_sales_des", help="Sort order used by the API"),
+) -> None:
+    """Fetch items from Taobao Alliance and store them in the database."""
+
+    settings = _get_settings(ctx)
+    engine = get_engine(settings.database_url)
+    create_tables(engine)
+
+    client = TaobaoClient(
+        app_key=settings.taobao.app_key,
+        app_secret=settings.taobao.app_secret,
+        adzone_id=settings.taobao.adzone_id,
+        endpoint=settings.taobao.endpoint,
+    )
+
+    keywords = settings.keywords
+    total = fetch_and_store(
+        client=client,
+        engine=engine,
+        keywords=keywords,
+        pages=pages,
+        page_size=page_size,
+        delay=delay,
+        has_coupon=not include_no_coupon,
+        sort=sort,
+    )
+    typer.echo(f"Stored {total} items for {len(keywords)} keyword(s).")
+
+
+@app.command("generate-copy")
+def generate_copy_command(
+    ctx: typer.Context,
+    item_id: List[int] = typer.Option(None, "--item-id", help="Generate creatives for specific item IDs"),
+    limit: Optional[int] = typer.Option(None, help="Limit the number of items to process"),
+    platform: List[str] = typer.Option(None, "--platform", help="Target platforms for copy generation"),
+    variants: int = typer.Option(3, help="Number of variants per platform"),
+) -> None:
+    """Generate creatives for stored items using OpenAI."""
+
+    settings = _get_settings(ctx)
+    llm_settings = settings.require_llm()
+    engine = get_engine(settings.database_url)
+    create_tables(engine)
+
+    platforms = platform or DEFAULT_PLATFORMS
+    copywriter = CopyWriter(
+        api_key=llm_settings.api_key,
+        model=llm_settings.model,
+        temperature=llm_settings.temperature,
+        provider=llm_settings.provider,
+        base_url=llm_settings.base_url,
+    )
+
+    creatives = generate_and_store_creatives(
+        copywriter=copywriter,
+        engine=engine,
+        platforms=platforms,
+        variants=variants,
+        limit=limit,
+        item_ids=item_id if item_id else None,
+    )
+    typer.echo(f"Generated {len(creatives)} creatives across {len(platforms)} platform(s).")
+
+
+@app.command("list-items")
+def list_items_command(
+    ctx: typer.Context,
+    limit: int = typer.Option(10, help="Number of items to display"),
+    category: List[str] = typer.Option(None, "--category", help="Filter by category"),
+) -> None:
+    """List stored items."""
+
+    settings = _get_settings(ctx)
+    engine = get_engine(settings.database_url)
+    items = fetch_items(engine, limit=limit, categories=category if category else None)
+    if not items:
+        typer.echo("No items found.")
+        return
+    for item in items:
+        typer.echo(
+            f"[{item.category}] {item.item_id} | {item.title} | 券后价: {item.coupon_price} | 月销量: {item.monthly_sales}"
+        )
+
+
+@app.command("list-creatives")
+def list_creatives_command(
+    ctx: typer.Context,
+    item_id: Optional[int] = typer.Option(None, help="Filter creatives by item id"),
+    limit: Optional[int] = typer.Option(10, help="Limit the number of creatives displayed"),
+) -> None:
+    """List generated creatives."""
+
+    settings = _get_settings(ctx)
+    engine = get_engine(settings.database_url)
+    creatives = list_creatives(engine, item_id=item_id)
+    if limit is not None:
+        creatives = creatives[:limit]
+    if not creatives:
+        typer.echo("No creatives found.")
+        return
+    for creative in creatives:
+        typer.echo(
+            f"Item {creative.item_id} | {creative.platform} #{creative.variant}: {creative.content[:80]}..."
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/hotflow/config.py
+++ b/hotflow/config.py
@@ -1,0 +1,264 @@
+"""Configuration helpers for HotFlow."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List, Optional
+import os
+
+try:  # pragma: no cover - optional dependency fallback
+    from dotenv import load_dotenv
+except ModuleNotFoundError:  # pragma: no cover
+    def load_dotenv(*args, **kwargs):
+        return False
+
+try:  # pragma: no cover - optional dependency fallback
+    from pydantic import BaseModel, ValidationError
+    HAS_PYDANTIC = True
+except ModuleNotFoundError:  # pragma: no cover
+    BaseModel = None  # type: ignore[assignment]
+    HAS_PYDANTIC = False
+
+    class ValidationError(Exception):  # type: ignore[override]
+        """Fallback validation error used when pydantic is unavailable."""
+
+        def __init__(self, message: str) -> None:
+            super().__init__(message)
+
+        def errors(self):  # pragma: no cover - compatibility helper
+            return [{"msg": str(self)}]
+DEFAULT_KEYWORDS = ["抽纸", "洗衣液", "猫粮", "狗粮", "猫砂"]
+
+
+def _split_keywords(raw: Optional[str]) -> List[str]:
+    if not raw:
+        return DEFAULT_KEYWORDS.copy()
+    values = [item.strip() for item in raw.split(",")]
+    return [item for item in values if item]
+
+
+@dataclass
+class TaobaoSettings:
+    """Holds credentials and API configuration for Taobao Alliance."""
+
+    app_key: str
+    app_secret: str
+    adzone_id: str
+    endpoint: str = "https://eco.taobao.com/router/rest"
+
+
+@dataclass
+class LLMSettings:
+    """Configuration for the copy generation language model."""
+
+    api_key: str
+    model: str = "gpt-4o-mini"
+    temperature: float = 0.7
+    base_url: Optional[str] = None
+    provider: str = "openai"
+
+
+@dataclass
+class Settings:
+    """Application wide settings."""
+
+    taobao: TaobaoSettings
+    database_url: str
+    keywords: List[str] = field(default_factory=lambda: DEFAULT_KEYWORDS.copy())
+    llm: Optional[LLMSettings] = None
+
+    def with_overrides(
+        self,
+        *,
+        keywords: Optional[Iterable[str]] = None,
+        database_url: Optional[str] = None,
+        openai_model: Optional[str] = None,
+        openai_temperature: Optional[float] = None,
+        copy_provider: Optional[str] = None,
+        openai_base_url: Optional[str] = None,
+    ) -> "Settings":
+        """Return a copy of the settings with runtime overrides applied."""
+
+        llm_settings = None
+        if self.llm:
+            llm_settings = LLMSettings(
+                api_key=self.llm.api_key,
+                model=self.llm.model,
+                temperature=self.llm.temperature,
+                base_url=self.llm.base_url,
+                provider=self.llm.provider,
+            )
+
+        updated = Settings(
+            taobao=self.taobao,
+            database_url=database_url or self.database_url,
+            keywords=list(keywords) if keywords else self.keywords.copy(),
+            llm=llm_settings,
+        )
+        if updated.llm and copy_provider:
+            updated.llm.provider = copy_provider.lower()
+        if updated.llm and openai_model:
+            updated.llm.model = openai_model
+        if updated.llm and openai_temperature is not None:
+            updated.llm.temperature = openai_temperature
+        if updated.llm and openai_base_url:
+            updated.llm.base_url = openai_base_url
+        return updated
+
+    def require_llm(self) -> LLMSettings:
+        if not self.llm:
+            raise RuntimeError(
+                "Copy generation credentials are required. Configure OPENAI_API_KEY or DEEPSEEK_API_KEY in the environment."
+            )
+        return self.llm
+
+    # Backwards compatibility for previous callers.
+    def require_openai(self) -> LLMSettings:  # pragma: no cover - thin wrapper
+        return self.require_llm()
+
+
+if HAS_PYDANTIC:
+
+    class _SettingsModel(BaseModel):
+        tb_app_key: str
+        tb_app_secret: str
+        tb_adzone_id: str
+        tb_endpoint: Optional[str] = None
+        hotflow_database_url: str
+        openai_api_key: Optional[str] = None
+        openai_model: Optional[str] = None
+        openai_temperature: Optional[float] = None
+        openai_base_url: Optional[str] = None
+        hotflow_copy_provider: Optional[str] = None
+        deepseek_api_key: Optional[str] = None
+        deepseek_model: Optional[str] = None
+        deepseek_temperature: Optional[float] = None
+        deepseek_base_url: Optional[str] = None
+        hotflow_keywords: Optional[str] = None
+
+else:
+
+    class _SettingsModel:  # pragma: no cover - fallback when pydantic is absent
+        def __init__(self, **env: str) -> None:
+            def _require(name: str) -> str:
+                value = env.get(name)
+                if value is None:
+                    raise ValidationError(f"Missing required configuration: {name}")
+                return value
+
+            def _optional_float(name: str) -> Optional[float]:
+                raw = env.get(name)
+                if raw in (None, ""):
+                    return None
+                try:
+                    return float(raw)
+                except ValueError as exc:  # pragma: no cover - validation helper
+                    raise ValidationError(f"Invalid float for {name}: {raw}") from exc
+
+            self.tb_app_key = _require("tb_app_key")
+            self.tb_app_secret = _require("tb_app_secret")
+            self.tb_adzone_id = _require("tb_adzone_id")
+            self.tb_endpoint = env.get("tb_endpoint")
+            self.hotflow_database_url = _require("hotflow_database_url")
+            self.openai_api_key = env.get("openai_api_key")
+            self.openai_model = env.get("openai_model")
+            self.openai_temperature = _optional_float("openai_temperature")
+            self.openai_base_url = env.get("openai_base_url")
+            self.hotflow_copy_provider = env.get("hotflow_copy_provider")
+            self.deepseek_api_key = env.get("deepseek_api_key")
+            self.deepseek_model = env.get("deepseek_model")
+            self.deepseek_temperature = _optional_float("deepseek_temperature")
+            self.deepseek_base_url = env.get("deepseek_base_url")
+            self.hotflow_keywords = env.get("hotflow_keywords")
+
+
+def load_settings(**overrides) -> Settings:
+    """Load configuration from environment variables and optional overrides."""
+
+    load_dotenv()
+    env = {key.lower(): value for key, value in os.environ.items()}
+
+    try:
+        model = _SettingsModel(**env)
+    except ValidationError as exc:  # pragma: no cover - reformat error message
+        errors = "; ".join(err.get("msg", "") for err in exc.errors())
+        raise RuntimeError(f"Invalid configuration: {errors}") from exc
+
+    taobao = TaobaoSettings(
+        app_key=model.tb_app_key,
+        app_secret=model.tb_app_secret,
+        adzone_id=model.tb_adzone_id,
+        endpoint=model.tb_endpoint or "https://eco.taobao.com/router/rest",
+    )
+
+    keywords = overrides.get("keywords")
+    if keywords:
+        keyword_list = list(keywords)
+    else:
+        override_keywords = overrides.get("hotflow_keywords")
+        if override_keywords:
+            keyword_list = list(override_keywords)
+        else:
+            keyword_list = _split_keywords(model.hotflow_keywords)
+
+    provider_override = overrides.get("copy_provider")
+    provider = (provider_override or model.hotflow_copy_provider or "openai").lower()
+
+    llm_settings: Optional[LLMSettings] = None
+    if provider == "deepseek":
+        api_key = overrides.get("deepseek_api_key") or model.deepseek_api_key
+        if api_key:
+            llm_settings = LLMSettings(
+                api_key=api_key,
+                model=(
+                    overrides.get("openai_model")
+                    or overrides.get("deepseek_model")
+                    or model.openai_model
+                    or model.deepseek_model
+                    or "deepseek-chat"
+                ),
+                temperature=float(
+                    overrides.get("openai_temperature")
+                    or overrides.get("deepseek_temperature")
+                    or model.openai_temperature
+                    or model.deepseek_temperature
+                    or 0.7
+                ),
+                base_url=(
+                    overrides.get("openai_base_url")
+                    or overrides.get("deepseek_base_url")
+                    or model.openai_base_url
+                    or model.deepseek_base_url
+                    or "https://api.deepseek.com"
+                ),
+                provider="deepseek",
+            )
+    else:
+        api_key = overrides.get("openai_api_key") or model.openai_api_key
+        if api_key:
+            llm_settings = LLMSettings(
+                api_key=api_key,
+                model=overrides.get("openai_model") or model.openai_model or "gpt-4o-mini",
+                temperature=float(
+                    overrides.get("openai_temperature")
+                    or model.openai_temperature
+                    or 0.7
+                ),
+                base_url=overrides.get("openai_base_url") or model.openai_base_url,
+                provider="openai",
+            )
+
+    settings = Settings(
+        taobao=taobao,
+        database_url=overrides.get("database_url") or model.hotflow_database_url,
+        keywords=keyword_list,
+        llm=llm_settings,
+    )
+    return settings
+
+
+__all__ = [
+    "Settings",
+    "TaobaoSettings",
+    "LLMSettings",
+    "load_settings",
+]

--- a/hotflow/copymaker.py
+++ b/hotflow/copymaker.py
@@ -1,0 +1,126 @@
+"""Utilities to generate creatives using OpenAI models."""
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Sequence
+import json
+import logging
+
+from openai import OpenAI
+
+from .models import Creative, Item
+from .prompts import DEFAULT_PLATFORMS, build_prompt
+
+logger = logging.getLogger(__name__)
+
+
+class CopyWriter:
+    """Generate creatives for Taobao items using LLMs."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str = "gpt-4o-mini",
+        temperature: float = 0.7,
+        provider: str = "openai",
+        base_url: Optional[str] = None,
+        client: Optional[OpenAI] = None,
+    ) -> None:
+        self.model = model
+        self.temperature = temperature
+        client_kwargs = {"api_key": api_key}
+        if base_url:
+            client_kwargs["base_url"] = base_url
+        self.client = client or OpenAI(**client_kwargs)
+        self.provider = provider
+        self.base_url = base_url
+
+    def _parse_response(
+        self,
+        payload: str,
+        platforms: Sequence[str],
+        variants: int,
+    ) -> Dict[str, List[str]]:
+        text = payload.strip()
+        if text.startswith("```"):
+            text = text.strip("`")
+            if "{" in text:
+                text = text[text.find("{") : text.rfind("}") + 1]
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            logger.warning("Failed to parse response as JSON. Falling back to raw text.")
+            return {platforms[0]: [payload.strip()]}
+
+        results: Dict[str, List[str]] = {}
+        for platform in platforms:
+            value = data.get(platform)
+            texts: List[str] = []
+            if isinstance(value, list):
+                texts = [str(item).strip() for item in value if str(item).strip()]
+            elif isinstance(value, str):
+                texts = [value.strip()]
+            else:
+                logger.debug("Platform %s missing or invalid in response", platform)
+            if len(texts) > variants:
+                texts = texts[:variants]
+            results[platform] = texts
+        return results
+
+    def generate(
+        self,
+        item: Item,
+        *,
+        platforms: Sequence[str] = DEFAULT_PLATFORMS,
+        variants: int = 3,
+        extra_system_prompt: Optional[str] = None,
+    ) -> List[Creative]:
+        prompt = build_prompt(item, platforms, variants)
+        messages = []
+        if extra_system_prompt:
+            messages.append({"role": "system", "content": extra_system_prompt})
+        messages.append({"role": "user", "content": prompt})
+
+        logger.debug(
+            "Calling %s model %s for item %s",
+            self.provider,
+            self.model,
+            item.item_id,
+        )
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            temperature=self.temperature,
+        )
+        message = response.choices[0].message
+        content = message.content or ""
+        parsed = self._parse_response(content, platforms, variants)
+
+        creatives: List[Creative] = []
+        for platform in platforms:
+            texts = parsed.get(platform) or []
+            if not texts:
+                continue
+            for idx, text in enumerate(texts, start=1):
+                creatives.append(
+                    Creative(
+                        item_id=item.item_id,
+                        platform=platform,
+                        variant=idx,
+                        content=text,
+                        prompt=prompt,
+                        model=self.model,
+                        temperature=self.temperature,
+                        provider=self.provider,
+                        metadata={
+                            "platforms": list(platforms),
+                            "variants_requested": variants,
+                        },
+                    )
+                )
+        if not creatives:
+            logger.warning("No creatives generated for item %s", item.item_id)
+        return creatives
+
+
+__all__ = ["CopyWriter"]

--- a/hotflow/db.py
+++ b/hotflow/db.py
@@ -1,0 +1,194 @@
+"""Database utilities for HotFlow."""
+from __future__ import annotations
+
+from typing import Iterable, List, Optional, Sequence
+import json
+
+from sqlalchemy import (
+    BigInteger,
+    Column,
+    DateTime,
+    Float,
+    Integer,
+    MetaData,
+    Numeric,
+    String,
+    Table,
+    Text,
+    and_,
+    create_engine,
+    func,
+    select,
+)
+from sqlalchemy.engine import Engine
+
+from .models import Creative, Item
+
+metadata = MetaData()
+
+
+taoke_items = Table(
+    "taoke_items",
+    metadata,
+    Column("item_id", BigInteger, primary_key=True),
+    Column("category", String(64), nullable=False),
+    Column("title", Text, nullable=False),
+    Column("image_url", Text),
+    Column("coupon_price", Numeric(10, 2)),
+    Column("price", Numeric(10, 2)),
+    Column("commission_rate", Numeric(10, 4)),
+    Column("monthly_sales", Integer),
+    Column("shop_score", Numeric(10, 4)),
+    Column("shop_title", String(255)),
+    Column("item_url", Text),
+    Column("coupon_url", Text),
+    Column("coupon_info", Text),
+    Column("tags", Text),
+    Column("raw", Text),
+    Column("updated_at", DateTime(timezone=True), server_default=func.now(), onupdate=func.now()),
+)
+
+
+creatives = Table(
+    "creatives",
+    metadata,
+    Column("creative_id", String(64), primary_key=True),
+    Column("item_id", BigInteger, nullable=False),
+    Column("platform", String(32), nullable=False),
+    Column("variant", Integer, nullable=False),
+    Column("content", Text, nullable=False),
+    Column("prompt", Text, nullable=False),
+    Column("model", String(64), nullable=False),
+    Column("temperature", Float, nullable=False),
+    Column("provider", String(32), nullable=False),
+    Column("metadata", Text),
+    Column("created_at", DateTime(timezone=True), server_default=func.now()),
+)
+
+
+def get_engine(database_url: str) -> Engine:
+    return create_engine(database_url)
+
+
+def create_tables(engine: Engine) -> None:
+    metadata.create_all(engine)
+
+
+def store_items(engine: Engine, items: Iterable[Item]) -> int:
+    items = list(items)
+    if not items:
+        return 0
+
+    with engine.begin() as conn:
+        ids = [item.item_id for item in items]
+        conn.execute(taoke_items.delete().where(taoke_items.c.item_id.in_(ids)))
+        rows = []
+        for item in items:
+            record = item.to_record()
+            record["raw"] = json.dumps(record["raw"], ensure_ascii=False)
+            rows.append(record)
+        conn.execute(taoke_items.insert(), rows)
+    return len(items)
+
+
+def fetch_items(
+    engine: Engine,
+    *,
+    limit: Optional[int] = None,
+    categories: Optional[Sequence[str]] = None,
+    item_ids: Optional[Sequence[int]] = None,
+) -> List[Item]:
+    stmt = select(taoke_items).order_by(taoke_items.c.updated_at.desc())
+    conditions = []
+    if categories:
+        conditions.append(taoke_items.c.category.in_(categories))
+    if item_ids:
+        conditions.append(taoke_items.c.item_id.in_(item_ids))
+    if conditions:
+        stmt = stmt.where(and_(*conditions))
+    if limit:
+        stmt = stmt.limit(limit)
+
+    with engine.begin() as conn:
+        rows = conn.execute(stmt).fetchall()
+
+    items: List[Item] = []
+    for row in rows:
+        raw_data = json.loads(row.raw) if row.raw else {}
+        tags = row.tags.split(",") if row.tags else []
+        items.append(
+            Item(
+                item_id=row.item_id,
+                category=row.category,
+                title=row.title,
+                image_url=row.image_url,
+                price=row.price,
+                coupon_price=row.coupon_price,
+                commission_rate=row.commission_rate,
+                monthly_sales=row.monthly_sales,
+                shop_score=row.shop_score,
+                shop_title=row.shop_title,
+                item_url=row.item_url,
+                coupon_url=row.coupon_url,
+                coupon_info=row.coupon_info,
+                tags=tags,
+                raw=raw_data,
+            )
+        )
+    return items
+
+
+def store_creatives(engine: Engine, creatives_to_store: Iterable[Creative]) -> int:
+    creatives_list = list(creatives_to_store)
+    if not creatives_list:
+        return 0
+
+    with engine.begin() as conn:
+        rows = []
+        for creative in creatives_list:
+            record = creative.to_record()
+            record["metadata"] = json.dumps(record.get("metadata") or {}, ensure_ascii=False)
+            rows.append(record)
+        conn.execute(creatives.insert(), rows)
+    return len(creatives_list)
+
+
+def list_creatives(engine: Engine, *, item_id: Optional[int] = None) -> List[Creative]:
+    stmt = select(creatives).order_by(creatives.c.created_at.desc())
+    if item_id is not None:
+        stmt = stmt.where(creatives.c.item_id == item_id)
+
+    with engine.begin() as conn:
+        rows = conn.execute(stmt).fetchall()
+
+    results: List[Creative] = []
+    for row in rows:
+        metadata_payload = json.loads(row.metadata) if row.metadata else {}
+        results.append(
+            Creative(
+                creative_id=row.creative_id,
+                item_id=row.item_id,
+                platform=row.platform,
+                variant=row.variant,
+                content=row.content,
+                prompt=row.prompt,
+                model=row.model,
+                temperature=row.temperature,
+                provider=row.provider,
+                metadata=metadata_payload,
+            )
+        )
+    return results
+
+
+__all__ = [
+    "get_engine",
+    "create_tables",
+    "store_items",
+    "fetch_items",
+    "store_creatives",
+    "list_creatives",
+    "metadata",
+    "taoke_items",
+    "creatives",
+]

--- a/hotflow/models.py
+++ b/hotflow/models.py
@@ -1,0 +1,86 @@
+"""Domain models used across the HotFlow package."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Dict, List, Optional
+import uuid
+
+
+@dataclass
+class Item:
+    """A simplified view of a Taobao Alliance item."""
+
+    item_id: int
+    category: str
+    title: str
+    image_url: Optional[str] = None
+    price: Optional[Decimal] = None
+    coupon_price: Optional[Decimal] = None
+    commission_rate: Optional[Decimal] = None
+    monthly_sales: Optional[int] = None
+    shop_score: Optional[Decimal] = None
+    shop_title: Optional[str] = None
+    item_url: Optional[str] = None
+    coupon_url: Optional[str] = None
+    coupon_info: Optional[str] = None
+    tags: List[str] = field(default_factory=list)
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+    def to_record(self) -> Dict[str, Any]:
+        """Convert the item into a database friendly dictionary."""
+
+        return {
+            "item_id": int(self.item_id),
+            "category": self.category,
+            "title": self.title,
+            "image_url": self.image_url,
+            "coupon_price": float(self.coupon_price) if self.coupon_price is not None else None,
+            "price": float(self.price) if self.price is not None else None,
+            "commission_rate": float(self.commission_rate) if self.commission_rate is not None else None,
+            "monthly_sales": self.monthly_sales,
+            "shop_score": float(self.shop_score) if self.shop_score is not None else None,
+            "shop_title": self.shop_title,
+            "item_url": self.item_url,
+            "coupon_url": self.coupon_url,
+            "coupon_info": self.coupon_info,
+            "tags": ",".join(self.tags),
+            "raw": self.raw,
+            "updated_at": datetime.utcnow(),
+        }
+
+
+@dataclass
+class Creative:
+    """Represents an AI generated creative."""
+
+    item_id: int
+    platform: str
+    variant: int
+    content: str
+    prompt: str
+    model: str
+    temperature: float
+    provider: str = "openai"
+    creative_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_record(self) -> Dict[str, Any]:
+        return {
+            "creative_id": self.creative_id,
+            "item_id": int(self.item_id),
+            "platform": self.platform,
+            "variant": self.variant,
+            "content": self.content,
+            "prompt": self.prompt,
+            "model": self.model,
+            "temperature": self.temperature,
+            "provider": self.provider,
+            "metadata": self.metadata,
+            "created_at": self.created_at,
+        }
+
+
+__all__ = ["Item", "Creative"]

--- a/hotflow/pipeline.py
+++ b/hotflow/pipeline.py
@@ -1,0 +1,68 @@
+"""High level orchestration helpers for HotFlow."""
+from __future__ import annotations
+
+from typing import Iterable, List, Optional, Sequence
+import logging
+
+from sqlalchemy.engine import Engine
+
+from .copymaker import CopyWriter
+from .db import fetch_items, store_creatives, store_items
+from .models import Creative, Item
+from .taobao import TaobaoClient
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_and_store(
+    *,
+    client: TaobaoClient,
+    engine: Engine,
+    keywords: Iterable[str],
+    pages: int = 1,
+    page_size: int = 50,
+    delay: float = 1.0,
+    **options,
+) -> int:
+    """Fetch items for each keyword and persist them."""
+
+    total_items = 0
+    for keyword in keywords:
+        logger.info("Fetching keyword '%s'", keyword)
+        items = client.fetch_many(keyword, pages=pages, page_size=page_size, delay=delay, **options)
+        if not items:
+            logger.warning("No items returned for keyword '%s'", keyword)
+            continue
+        stored = store_items(engine, items)
+        logger.info("Stored %s items for keyword '%s'", stored, keyword)
+        total_items += stored
+    return total_items
+
+
+def generate_and_store_creatives(
+    *,
+    copywriter: CopyWriter,
+    engine: Engine,
+    platforms: Sequence[str],
+    variants: int = 3,
+    limit: Optional[int] = None,
+    categories: Optional[Sequence[str]] = None,
+    item_ids: Optional[Sequence[int]] = None,
+) -> List[Creative]:
+    """Generate creatives for items and persist them."""
+
+    items = fetch_items(engine, limit=limit, categories=categories, item_ids=item_ids)
+    if not items:
+        logger.warning("No items found for creative generation")
+        return []
+
+    all_creatives: List[Creative] = []
+    for item in items:
+        logger.info("Generating creatives for item %s", item.item_id)
+        generated = copywriter.generate(item, platforms=platforms, variants=variants)
+        all_creatives.extend(generated)
+        store_creatives(engine, generated)
+    return all_creatives
+
+
+__all__ = ["fetch_and_store", "generate_and_store_creatives"]

--- a/hotflow/prompts.py
+++ b/hotflow/prompts.py
@@ -1,0 +1,74 @@
+"""Prompt templates used for creative generation."""
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Sequence
+
+from .models import Item
+
+PLATFORM_LABELS = {
+    "xiaohongshu": "小红书图文笔记",
+    "weibo": "微博短文",
+    "zhihu": "知乎回答",
+}
+
+DEFAULT_PLATFORMS = ["xiaohongshu", "weibo", "zhihu"]
+
+PROMPT_TEMPLATE = """你是一名擅长电商种草文案的写手, 擅长用真实体验打动消费者。\n\n请根据以下商品信息, 为每个平台生成 {variants} 条不同风格的推广文案。\n\n输出要求:\n1. 每个平台输出一个数组, 其中包含 {variants} 条文案字符串。\n2. 结果必须是 JSON 格式, 字段名使用平台英文标识: {platform_keys}。\n3. 文案需要自然真实, 强调省钱、使用体验和复购感受。\n4. 合理添加 emoji, 但避免过度使用。\n\n商品信息:\n- 品类: {category}\n- 名称: {title}\n- 券后价: {coupon_price}\n- 原价: {price}\n- 月销量: {monthly_sales}\n- 店铺: {shop_title}\n- 核心卖点: {features}\n- 优惠信息: {coupon_info}\n\n如果信息缺失, 请合理发挥但不要捏造夸张数据。"""
+
+
+def _format_price(value: Decimal | None) -> str:
+    if value is None:
+        return "未知"
+    return f"¥{value:.2f}"
+
+
+def _format_sales(value: int | None) -> str:
+    if value is None:
+        return "未知"
+    if value >= 10000:
+        return f"{value / 10000:.1f}万+"
+    return str(value)
+
+
+def derive_features(item: Item) -> str:
+    raw = item.raw or {}
+    features: list[str] = []
+    highlight = raw.get("item_description") or raw.get("item_short_title")
+    if highlight:
+        features.append(highlight)
+    if raw.get("provcity"):
+        features.append(f"发货地 {raw['provcity']}")
+    if raw.get("level_one_category_name"):
+        features.append(f"类目：{raw['level_one_category_name']}")
+    if raw.get("small_images"):
+        images = raw["small_images"].get("string") if isinstance(raw["small_images"], dict) else raw["small_images"]
+        if isinstance(images, list) and images:
+            features.append(f"精选图{len(images)}张")
+    if item.tags:
+        features.append("#" + " #".join(item.tags))
+    if not features:
+        features.append("口碑好, 性价比高")
+    return "；".join(features)
+
+
+def build_prompt(item: Item, platforms: Sequence[str], variants: int) -> str:
+    keys = ", ".join(platforms)
+    features = derive_features(item)
+    coupon_info = item.coupon_info or "下单立减, 先到先得"
+    prompt = PROMPT_TEMPLATE.format(
+        variants=variants,
+        platform_keys=keys,
+        category=item.category,
+        title=item.title,
+        coupon_price=_format_price(item.coupon_price or item.price),
+        price=_format_price(item.price),
+        monthly_sales=_format_sales(item.monthly_sales),
+        shop_title=item.shop_title or "优质店铺",
+        features=features,
+        coupon_info=coupon_info,
+    )
+    return prompt
+
+
+__all__ = ["build_prompt", "derive_features", "DEFAULT_PLATFORMS", "PLATFORM_LABELS"]

--- a/hotflow/taobao.py
+++ b/hotflow/taobao.py
@@ -1,0 +1,212 @@
+"""Taobao Alliance API client and helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Dict, List, Optional
+import hashlib
+import logging
+import time
+
+try:  # pragma: no cover - optional dependency fallback
+    import requests
+except ModuleNotFoundError:  # pragma: no cover
+    requests = None  # type: ignore[assignment]
+
+from .models import Item
+
+logger = logging.getLogger(__name__)
+
+
+class TaobaoAPIError(RuntimeError):
+    """Raised when the Taobao API returns an error response."""
+
+
+@dataclass
+class SearchResult:
+    items: List[Item]
+    total_results: Optional[int]
+    page_no: int
+    page_size: int
+
+
+def _safe_decimal(value: Any) -> Optional[Decimal]:
+    if value in (None, ""):
+        return None
+    try:
+        return Decimal(str(value))
+    except Exception:  # pragma: no cover - defensive
+        logger.debug("Failed to convert %s to Decimal", value)
+        return None
+
+
+def _safe_int(value: Any) -> Optional[int]:
+    if value in (None, ""):
+        return None
+    try:
+        return int(float(value))
+    except Exception:  # pragma: no cover - defensive
+        logger.debug("Failed to convert %s to int", value)
+        return None
+
+
+class TaobaoClient:
+    """A thin wrapper around the Taobao Alliance material optional API."""
+
+    def __init__(
+        self,
+        *,
+        app_key: str,
+        app_secret: str,
+        adzone_id: str,
+        endpoint: str = "https://eco.taobao.com/router/rest",
+        session: Optional[requests.Session] = None,
+        timeout: float = 10.0,
+    ) -> None:
+        if requests is None:  # pragma: no cover - runtime guard
+            raise RuntimeError(
+                "The 'requests' package is required to use TaobaoClient. Install requests to enable network calls."
+            )
+        self.app_key = app_key
+        self.app_secret = app_secret
+        self.adzone_id = adzone_id
+        self.endpoint = endpoint
+        self.session = session or requests.Session()
+        self.timeout = timeout
+
+    @staticmethod
+    def sign(params: Dict[str, Any], secret: str) -> str:
+        """Generate a Taobao API signature."""
+
+        ordered = sorted((k, v) for k, v in params.items() if v is not None)
+        base = secret + "".join(f"{key}{value}" for key, value in ordered) + secret
+        return hashlib.md5(base.encode("utf-8")).hexdigest().upper()
+
+    def _build_params(self, extra: Dict[str, Any]) -> Dict[str, Any]:
+        params: Dict[str, Any] = {
+            "method": "taobao.tbk.dg.material.optional",
+            "app_key": self.app_key,
+            "sign_method": "md5",
+            "timestamp": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
+            "format": "json",
+            "v": "2.0",
+            "adzone_id": self.adzone_id,
+        }
+        params.update({key: value for key, value in extra.items() if value is not None})
+        params["sign"] = self.sign(params, self.app_secret)
+        return params
+
+    def _request(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        response = self.session.get(self.endpoint, params=params, timeout=self.timeout)
+        response.raise_for_status()
+        payload = response.json()
+        if "error_response" in payload:
+            error = payload["error_response"]
+            code = error.get("code")
+            message = error.get("msg") or error.get("sub_msg")
+            raise TaobaoAPIError(f"Taobao API error {code}: {message}")
+        return payload.get("tbk_dg_material_optional_response", {})
+
+    @staticmethod
+    def _parse_item(raw: Dict[str, Any], keyword: str) -> Item:
+        price = _safe_decimal(raw.get("zk_final_price"))
+        original_price = _safe_decimal(raw.get("reserve_price")) or price
+        coupon_amount = _safe_decimal(raw.get("coupon_amount"))
+        coupon_price = price
+        if price is not None and coupon_amount is not None:
+            coupon_price = price - coupon_amount
+            if coupon_price < Decimal("0"):
+                coupon_price = Decimal("0")
+
+        commission_rate = _safe_decimal(raw.get("commission_rate"))
+        if commission_rate is not None:
+            commission_rate = commission_rate / Decimal("100")
+
+        monthly_sales = _safe_int(raw.get("volume") or raw.get("month_sales"))
+        shop_score = _safe_decimal(raw.get("shop_dsr"))
+
+        coupon_info_parts: List[str] = []
+        if raw.get("coupon_start_fee") and raw.get("coupon_amount"):
+            coupon_info_parts.append(
+                f"满{raw['coupon_start_fee']}减{raw['coupon_amount']}"
+            )
+        if raw.get("coupon_end_time"):
+            coupon_info_parts.append(f"券有效期至{raw['coupon_end_time']}")
+
+        coupon_info = "；".join(coupon_info_parts) or raw.get("coupon_info")
+
+        return Item(
+            item_id=int(raw["item_id"]),
+            category=keyword,
+            title=raw.get("short_title") or raw.get("title") or "",
+            image_url=raw.get("pict_url"),
+            price=original_price,
+            coupon_price=coupon_price,
+            commission_rate=commission_rate,
+            monthly_sales=monthly_sales,
+            shop_score=shop_score,
+            shop_title=raw.get("shop_title") or raw.get("shop_dsr"),
+            item_url=raw.get("url") or raw.get("item_url"),
+            coupon_url=raw.get("coupon_share_url") or raw.get("coupon_click_url"),
+            coupon_info=coupon_info,
+            tags=[keyword],
+            raw=raw,
+        )
+
+    def search(
+        self,
+        keyword: str,
+        *,
+        page_no: int = 1,
+        page_size: int = 50,
+        has_coupon: bool = True,
+        sort: str = "total_sales_des",
+        extra_params: Optional[Dict[str, Any]] = None,
+    ) -> SearchResult:
+        """Search items by keyword."""
+
+        params = {
+            "q": keyword,
+            "page_no": page_no,
+            "page_size": page_size,
+            "sort": sort,
+        }
+        if has_coupon:
+            params["has_coupon"] = "true"
+        if extra_params:
+            params.update(extra_params)
+
+        signed_params = self._build_params(params)
+        payload = self._request(signed_params)
+        result_list = payload.get("result_list", {}).get("map_data", [])
+        items = [self._parse_item(entry, keyword) for entry in result_list if entry]
+        total_results = payload.get("total_results")
+        return SearchResult(items=items, total_results=total_results, page_no=page_no, page_size=page_size)
+
+    def fetch_many(
+        self,
+        keyword: str,
+        *,
+        pages: int = 1,
+        page_size: int = 50,
+        delay: float = 1.0,
+        **options: Any,
+    ) -> List[Item]:
+        """Fetch multiple pages of results for a keyword."""
+
+        collected: List[Item] = []
+        for page in range(1, pages + 1):
+            result = self.search(keyword, page_no=page, page_size=page_size, **options)
+            if not result.items:
+                break
+            collected.extend(result.items)
+            if len(result.items) < page_size:
+                break
+            if delay:
+                time.sleep(delay)
+        return collected
+
+
+__all__ = ["TaobaoClient", "TaobaoAPIError", "SearchResult"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hotflow"
+version = "0.1.0"
+description = "Taobao Alliance data ingestion and AI copy generation pipeline"
+readme = "README.md"
+authors = [{name = "HotFlow"}]
+requires-python = ">=3.10"
+dependencies = [
+    "requests>=2.31.0",
+    "SQLAlchemy>=2.0.25",
+    "python-dotenv>=1.0.1",
+    "openai>=1.10.0",
+    "pydantic>=2.6.0",
+    "typer>=0.12.3",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+]
+
+[project.scripts]
+hotflow = "hotflow.cli:app"
+
+[tool.pytest.ini_options]
+addopts = "-q"
+pythonpath = ["."]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,57 @@
+"""Tests for configuration loading and provider selection."""
+
+from __future__ import annotations
+
+import pytest
+
+from hotflow.config import LLMSettings, load_settings
+
+
+@pytest.fixture(autouse=True)
+def clear_env(monkeypatch: pytest.MonkeyPatch):
+    """Clear LLM-related environment variables before each test."""
+
+    keys = [
+        "OPENAI_API_KEY",
+        "OPENAI_MODEL",
+        "OPENAI_TEMPERATURE",
+        "OPENAI_BASE_URL",
+        "HOTFLOW_COPY_PROVIDER",
+        "DEEPSEEK_API_KEY",
+        "DEEPSEEK_MODEL",
+        "DEEPSEEK_TEMPERATURE",
+        "DEEPSEEK_BASE_URL",
+        "HOTFLOW_KEYWORDS",
+    ]
+    for key in keys:
+        monkeypatch.delenv(key, raising=False)
+    # Required Taobao/database keys for successful configuration load
+    monkeypatch.setenv("TB_APP_KEY", "key")
+    monkeypatch.setenv("TB_APP_SECRET", "secret")
+    monkeypatch.setenv("TB_ADZONE_ID", "zone")
+    monkeypatch.setenv("HOTFLOW_DATABASE_URL", "sqlite://")
+    yield
+    for key in keys:
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_load_settings_defaults_to_openai(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    settings = load_settings()
+    llm = settings.require_llm()
+    assert isinstance(llm, LLMSettings)
+    assert llm.provider == "openai"
+    assert llm.model == "gpt-4o-mini"
+    assert llm.base_url is None
+
+
+def test_load_settings_supports_deepseek(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOTFLOW_COPY_PROVIDER", "deepseek")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "ds-key")
+    settings = load_settings()
+    llm = settings.require_llm()
+    assert llm.provider == "deepseek"
+    assert llm.api_key == "ds-key"
+    assert llm.model == "deepseek-chat"
+    assert llm.base_url == "https://api.deepseek.com"
+

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,37 @@
+from decimal import Decimal
+
+from hotflow.models import Item
+from hotflow.prompts import build_prompt, derive_features
+
+
+def make_item() -> Item:
+    return Item(
+        item_id=1,
+        category="猫粮",
+        title="优质猫粮",
+        price=Decimal("79.9"),
+        coupon_price=Decimal("69.9"),
+        commission_rate=Decimal("0.15"),
+        monthly_sales=1234,
+        shop_score=Decimal("4.9"),
+        shop_title="旗舰店",
+        item_url="https://example.com",
+        coupon_url="https://example.com/coupon",
+        coupon_info="满减优惠",
+        raw={"provcity": "上海", "level_one_category_name": "宠物用品"},
+    )
+
+
+def test_build_prompt_contains_core_fields():
+    item = make_item()
+    prompt = build_prompt(item, ["xiaohongshu", "weibo"], 2)
+    assert "优质猫粮" in prompt
+    assert "满减优惠" in prompt
+    assert "xiaohongshu" in prompt
+    assert "¥69.90" in prompt
+
+
+def test_derive_features_falls_back_to_default():
+    item = Item(item_id=2, category="抽纸", title="抽纸", raw={})
+    features = derive_features(item)
+    assert "性价比" in features

--- a/tests/test_taobao.py
+++ b/tests/test_taobao.py
@@ -1,0 +1,21 @@
+from hotflow.taobao import TaobaoClient
+
+
+def test_sign_generates_expected_hash():
+    params = {
+        "app_key": "123456",
+        "method": "taobao.test",
+        "timestamp": "2024-01-01 00:00:00",
+        "format": "json",
+    }
+    secret = "abcdefg"
+    expected_base = (
+        secret
+        + "app_key123456"
+        + "formatjson"
+        + "methodtaobao.test"
+        + "timestamp2024-01-01 00:00:00"
+        + secret
+    )
+    expected = __import__("hashlib").md5(expected_base.encode("utf-8")).hexdigest().upper()
+    assert TaobaoClient.sign(params, secret) == expected


### PR DESCRIPTION
## Summary
- introduce provider-aware LLM settings with DeepSeek defaults and wire them through the CLI and copywriter
- document the new DeepSeek configuration knobs and harden top-level imports against missing optional dependencies
- add configuration tests covering OpenAI and DeepSeek selection paths

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cb715f00088331acf9a51ea53c6481